### PR TITLE
No classList for no-touch browsers.

### DIFF
--- a/FastActive.js
+++ b/FastActive.js
@@ -2,7 +2,7 @@
     var hasTouch = (('ontouchstart' in w) || w.DocumentTouch && d instanceof DocumentTouch),
         docClass = d.documentElement.className;
     if (!hasTouch && (' '+docClass+' ').indexOf(' no-touch ') < 0) {
-        d.documentElement.className += (docClass.length?' ':'')+'no-touch';
+        d.documentElement.className += (docClass!=''?' ':'')+'no-touch';
     } else {
         var activeElement = null,
             clearActive = function() {

--- a/FastActive.js
+++ b/FastActive.js
@@ -1,7 +1,8 @@
 (function (d, w, activeClass) {
-    var hasTouch = (('ontouchstart' in w) || w.DocumentTouch && d instanceof DocumentTouch);
-    if (!hasTouch) {
-        d.documentElement.classList.add('no-touch');
+    var hasTouch = (('ontouchstart' in w) || w.DocumentTouch && d instanceof DocumentTouch),
+        docClass = d.documentElement.className;
+    if (!hasTouch && (' '+docClass+' ').indexOf(' no-touch ') < 0) {
+        d.documentElement.className += (docClass.length?' ':'')+'no-touch';
     } else {
         var activeElement = null,
             clearActive = function() {


### PR DESCRIPTION
To keep touch browsers from worrying about `:active` and `:hover` you suggest using the `.no-touch` class in CSS. However, because you are using `classList`, this class will not be available to over 15% of the web’s visitors (IE 8 and 9 per September 2013, [StatCounter](http://gs.statcounter.com/#browser_version-ww-monthly-201309-201309-bar)).

This patch modifies the no-touch part of the code to use simple string operations on `className` instead. I am assuming touch browsers support classList, and according to [Can I use…](http://caniuse.com/#search=classList) they do, so that part of the code has been left untouched.
